### PR TITLE
Timeout fix (http -> https)

### DIFF
--- a/controllers/Pakomato14.php
+++ b/controllers/Pakomato14.php
@@ -1,7 +1,7 @@
 <?php
 global $inpost_data_dir, $inpost_api_url;
 $inpost_data_dir = PACZKOMATY_PATH.'inpost/data';
-$inpost_api_url  = 'http://api.paczkomaty.pl';
+$inpost_api_url  = 'https://api.paczkomaty.pl';
 
 require_once PACZKOMATY_PATH.'inpost/functions.php';
 require_once PACZKOMATY_PATH.'inpost/inpost.php';

--- a/controllers/Pakomato15.php
+++ b/controllers/Pakomato15.php
@@ -1,7 +1,7 @@
 <?php
 global $inpost_data_dir, $inpost_api_url;
 $inpost_data_dir = PACZKOMATY_PATH.'inpost/data';
-$inpost_api_url  = 'http://api.paczkomaty.pl';
+$inpost_api_url  = 'https://api.paczkomaty.pl';
 
 require_once PACZKOMATY_PATH.'inpost/functions.php';
 require_once PACZKOMATY_PATH.'inpost/inpost.php';

--- a/controllers/Pakomato16.php
+++ b/controllers/Pakomato16.php
@@ -1,7 +1,7 @@
 <?php
 global $inpost_data_dir, $inpost_api_url;
 $inpost_data_dir = PACZKOMATY_PATH.'inpost/data';
-$inpost_api_url  = 'http://api.paczkomaty.pl';
+$inpost_api_url  = 'https://api.paczkomaty.pl';
 
 require_once PACZKOMATY_PATH.'inpost/functions.php';
 require_once PACZKOMATY_PATH.'inpost/inpost.php';

--- a/inpost/config.php
+++ b/inpost/config.php
@@ -11,6 +11,6 @@ Copyright (c) 2009 InPost
 global $inpost_data_dir, $inpost_api_url;
 
 //$inpost_data_dir = THIS_DIR.'inpost/data';
-$inpost_api_url  = 'http://api.paczkomaty.pl';
+$inpost_api_url  = 'https://api.paczkomaty.pl';
 
 ?>


### PR DESCRIPTION
Paczkomaty nie obsługują już HTTP. Moduł nadal działa i wiele osób z niego korzysta, a fix jest prosty.